### PR TITLE
Copy of main for npm release version 1.0

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -5,7 +5,7 @@ name: Deploy GH Page and NPM Package
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release_1.0 ]
 
 jobs:
 #  github_pages:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-json-chart-builder",
-  "version": "0.0.0-semantic",
+  "name": "@ansible/react-json-chart-builder",
+  "version": "1.0.0-semantic",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-json-chart-builder",
-      "version": "0.0.0-semantic",
+      "name": "@ansible/react-json-chart-builder",
+      "version": "1.0.0-semantic",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.14.6",


### PR DESCRIPTION
Made a copy of `main` branch, named it `release_1.0`. This branch will be used to push to npm as version 1.0.0 which uses Patternfly 4 (for use in crc). 

Jira issue: https://issues.redhat.com/browse/AAP-15632 