### PR TITLE
Update demo app to use PatternFly v6

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -3,12 +3,22 @@ import { Routes, Route } from 'react-router-dom';
 import {
   Button,
   ButtonVariant,
+  Masthead,
+  MastheadMain,
+  MastheadToggle,
+  MastheadBrand,
+  MastheadLogo,
+  MastheadContent,
   Page,
   PageSection,
   PageSidebar,
-  PageSidebarBody
+  PageSidebarBody,
+  PageToggleButton,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem
 } from '@patternfly/react-core';
-import { PageHeader, PageHeaderTools } from '@patternfly/react-core/deprecated';
+import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import { List, Show } from './Pages';
 import Navigation from './Navigation';
 import logo from '../public/favicon.png';
@@ -19,29 +29,46 @@ const jumpToDocs = () => {
 };
 
 const App: FC<Record<string, never>> = () => {
+  const [isSidebarOpen, setSidebarOpen] = React.useState(true);
+
   const headerToolbar = (
-    <PageHeaderTools
-      children={
-        <Button onClick={() => jumpToDocs()} variant={ButtonVariant.primary}>
-          Jump to docs
-        </Button>
-      }
-    />
+    <Toolbar>
+      <ToolbarContent>
+        <ToolbarItem>
+          <Button onClick={() => jumpToDocs()} variant={ButtonVariant.primary}>
+            Jump to docs
+          </Button>
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
   );
 
-  const Header = (
-    <PageHeader
-      logo={
-        <>
-          {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-          <img src={logo} width="30px" alt="Logo" />
-          <p style={{ marginLeft: '10px', color: 'white' }}>Chart builder demo</p>
-        </>
-      }
-      headerTools={headerToolbar}
-      showNavToggle
-    />
+  const masthead = (
+    <Masthead>
+      <MastheadMain>
+        <MastheadToggle>
+          <PageToggleButton
+            variant="plain"
+            aria-label="Global navigation"
+            isSidebarOpen={isSidebarOpen}
+            onSidebarToggle={() => setSidebarOpen(!isSidebarOpen)}
+            id="vertical-nav-toggle"
+          >
+            <BarsIcon />
+          </PageToggleButton>
+        </MastheadToggle>
+        <MastheadBrand>
+          <MastheadLogo href="https://patternfly.org" target="_blank">
+            {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
+            <img src={logo} width="30px" alt="Logo" />
+            <span style={{ marginLeft: '10px', marginTop: '10px' }}>Chart builder demo</span>
+          </MastheadLogo>
+        </MastheadBrand>
+      </MastheadMain>
+      <MastheadContent>{headerToolbar}</MastheadContent>
+    </Masthead>
   );
+
   const Sidebar = (
     <PageSidebar>
       <PageSidebarBody>
@@ -51,7 +78,7 @@ const App: FC<Record<string, never>> = () => {
   );
 
   return (
-    <Page header={Header} isManagedSidebar sidebar={Sidebar} style={{ minHeight: '100vh' }}>
+    <Page masthead={masthead} isManagedSidebar sidebar={Sidebar} style={{ minHeight: '100vh' }}>
       <PageSection isFilled>
         <Routes>
           <Route path="/" element={<List />} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "@babel/preset-env": "^7.23.2",
         "@babel/preset-react": "^7.22.15",
         "@patternfly/react-charts": "^8.2.0-prerelease.12",
-        "@patternfly/react-code-editor": "^5.1.1",
-        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-code-editor": "^6.2.0-prerelease.16",
+        "@patternfly/react-core": "^6.2.0-prerelease.15",
         "@semantic-release/changelog": "^6.0.3",
         "@testing-library/react": "^12.1.5",
         "@types/jest": "^27.5.2",
@@ -56,7 +56,7 @@
       },
       "peerDependencies": {
         "@patternfly/react-charts": "^8.2.0-prerelease.12",
-        "@patternfly/react-core": "^5.0.0",
+        "@patternfly/react-core": "^6.2.0-prerelease.15",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "victory": "^37.3.6"
@@ -2871,68 +2871,47 @@
       }
     },
     "node_modules/@patternfly/react-code-editor": {
-      "version": "5.4.15",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-5.4.15.tgz",
-      "integrity": "sha512-BtuwV5Plq80HMaKc8ZsvxtrjfPMZyxjEnIFFtx1jEuQzUgWu6jlW/086UzknKKkyGrxXD2cRs8XDFKMtryLeBg==",
+      "version": "6.2.0-prerelease.16",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.2.0-prerelease.16.tgz",
+      "integrity": "sha512-mO6pgzzggEKwpkh240VQIyHYcr265Jz2eS/QnHtESXcdrKfDl5PNlojbyqnpcEz6TglvPywvQgF2rI5BpWvIwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@patternfly/react-core": "^5.4.12",
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-styles": "^5.4.1",
-        "react-dropzone": "14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-core": "^6.2.0-prerelease.15",
+        "@patternfly/react-icons": "^6.2.0-prerelease.2",
+        "@patternfly/react-styles": "^6.2.0-prerelease.2",
+        "react-dropzone": "14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
-    "node_modules/@patternfly/react-code-editor/node_modules/@patternfly/react-styles": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
-      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@patternfly/react-core": {
-      "version": "5.4.12",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.12.tgz",
-      "integrity": "sha512-RI1xS1JGJdE/FvpkMzawaE21oeTc/e+WbxvFXqZfLhTz60P8RzVG1nYWXDL747Onkz3SYtY79PhQ8nsLeO5sJQ==",
+      "version": "6.2.0-prerelease.15",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.2.0-prerelease.15.tgz",
+      "integrity": "sha512-h8TdGxcX5Bkxb6c5cdP8Z0FEAeVcu4PO+dPncq2SXdMmFPvwUJfeklVGC8v81fclPPVtlijStFSM5aC5n1XjHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-styles": "^5.4.1",
-        "@patternfly/react-tokens": "^5.4.1",
-        "focus-trap": "7.6.2",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-icons": "^6.2.0-prerelease.2",
+        "@patternfly/react-styles": "^6.2.0-prerelease.2",
+        "@patternfly/react-tokens": "^6.2.0-prerelease.2",
+        "focus-trap": "7.6.4",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
-    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-styles": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
-      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@patternfly/react-core/node_modules/@patternfly/react-tokens": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
-      "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
-      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
+      "version": "6.2.0-prerelease.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.2.0-prerelease.2.tgz",
+      "integrity": "sha512-3ymG24ICMAvMqrDPzU8ycPcsHht4RfHjQil3ox43wwHI+nLrpywAgE9z6GtAzwtdm+DVZHBT1CWLWuAgdofX8w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -8288,13 +8267,13 @@
       }
     },
     "node_modules/file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">= 12"
@@ -8442,9 +8421,9 @@
       "license": "ISC"
     },
     "node_modules/focus-trap": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
-      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15731,14 +15710,14 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "version": "14.3.5",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.5.tgz",
+      "integrity": "sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@patternfly/react-charts": "^8.2.0-prerelease.12",
-    "@patternfly/react-core": "^5.0.0",
+    "@patternfly/react-core": "^6.2.0-prerelease.15",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "victory": "^37.3.6"
@@ -54,8 +54,8 @@
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-react": "^7.22.15",
     "@patternfly/react-charts": "^8.2.0-prerelease.12",
-    "@patternfly/react-code-editor": "^5.1.1",
-    "@patternfly/react-core": "^5.1.1",
+    "@patternfly/react-code-editor": "^6.2.0-prerelease.16",
+    "@patternfly/react-core": "^6.2.0-prerelease.15",
     "@semantic-release/changelog": "^6.0.3",
     "@testing-library/react": "^12.1.5",
     "@types/jest": "^27.5.2",


### PR DESCRIPTION
Update demo app to use latest PatternFly v6 packages.

Notes: 

- Must use latest pre-release packages because `useId` is not supported by React 18
- PageHeader and PageHeaderTools were deprecated and removed for v6
- Using Masthead components in place of PageHeader and PageHeaderTools

Example
![Screenshot 2025-02-10 at 11 51 44 AM](https://github.com/user-attachments/assets/3fb6970d-8ca3-442e-9e0e-1b5031c45ada)

